### PR TITLE
Add country support in search history

### DIFF
--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -47,7 +47,7 @@ const SearchBar = () => {
 
     const handleSuggestionClick = (selectedCity) => {
         setWeatherData({ city: selectedCity.name, id: selectedCity.id });
-        addToHistory({ name: selectedCity.name, id: selectedCity.id });
+        addToHistory({ name: selectedCity.name, id: selectedCity.id, country: selectedCity.country });
         setCity(selectedCity.name);
         setSuggestions([]);
         setErrorMessage('');
@@ -69,7 +69,7 @@ const SearchBar = () => {
 
         if (matchingCity) {
             setWeatherData({ city: matchingCity.name, id: matchingCity.id });
-            addToHistory({ name: matchingCity.name, id: matchingCity.id });
+            addToHistory({ name: matchingCity.name, id: matchingCity.id, country: matchingCity.country });
             setErrorMessage('');
             setCity(matchingCity.name);
         } else {

--- a/client/src/components/SearchHistory.jsx
+++ b/client/src/components/SearchHistory.jsx
@@ -26,7 +26,7 @@ const SearchHistory = () => {
               className={styles.historyItem}
               onClick={() => handleSelect(item)}
             >
-              {item.name}
+              {item.name}, {item.country}
             </button>
           ))
         )}

--- a/client/src/context/HistoryContext.jsx
+++ b/client/src/context/HistoryContext.jsx
@@ -33,7 +33,8 @@ export const HistoryProvider = ({ children }) => {
         if (Array.isArray(data)) {
           setHistory(data.map(item => ({
             name: item.city_name,
-            id: item.city_id
+            id: item.city_id,
+            country: item.country
           })));
         }
       })
@@ -45,8 +46,11 @@ export const HistoryProvider = ({ children }) => {
   }, [history]);
 
   const addToHistory = (city) => {
-    if (!history.some((item) => item.name === city.name)) {
-      setHistory((prev) => [{ name: city.name, id: city.id }, ...prev.slice(0, 9)]);
+    if (!history.some((item) => item.id === city.id)) {
+      setHistory((prev) => [
+        { name: city.name, id: city.id, country: city.country },
+        ...prev.slice(0, 9)
+      ]);
       persistHistory(city);
     }
   };
@@ -59,6 +63,7 @@ export const HistoryProvider = ({ children }) => {
         body: JSON.stringify({
           id: entry.id,
           name: entry.name,
+          country: entry.country,
           uuid: userUUID
         })
       });

--- a/server/src/controllers/weatherController.js
+++ b/server/src/controllers/weatherController.js
@@ -109,12 +109,13 @@ const getUserHistory = async (req, res) => {
 
 // POST /api/weather/history
 const addUserHistory = async (req, res) => {
-  const { id, name, uuid } = req.body;
+  const { id, name, country, uuid } = req.body;
   try {
     const entry = new WeatherHistory({
       user_uuid: uuid,
       city_name: name,
-      city_id: id
+      city_id: id,
+      country
     });
     await entry.save();
 

--- a/server/src/models/WeatherHistory.js
+++ b/server/src/models/WeatherHistory.js
@@ -13,6 +13,10 @@ const weatherHistorySchema = new mongoose.Schema({
     type: Number,
     required: true
   },
+  country: {
+    type: String,
+    required: true
+  },
   searched_at: {
     type: Date,
     default: Date.now

--- a/server/tests/weather.test.js
+++ b/server/tests/weather.test.js
@@ -46,6 +46,7 @@ describe('Weather API Endpoints', () => {
       const newEntry = {
         id: 5128581,
         name: 'New York',
+        country: 'US',
         uuid: '1234abcd-5678-efgh-ijkl-9876mnopqrst'
       };
       const response = await request(app)


### PR DESCRIPTION
## Summary
- include country when cities are saved from the SearchBar
- store and persist country with search history
- update WeatherHistory model and controller for country field
- show country in search history list
- adjust server tests for new field

## Testing
- `npm test --prefix client` *(fails: jest not found)*
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa4cdfac832b9b41a287e89bd181