### PR TITLE
Update favorites to include country

### DIFF
--- a/client/src/components/FavoritesList.jsx
+++ b/client/src/components/FavoritesList.jsx
@@ -16,13 +16,13 @@ const FavoritesList = () => {
         <>
           <div className={styles.favoritesList}>
             {favorites.map((city) => (
-              <span
-                key={city.id}
+              <button
+                key={`${city.id}-${city.country}`}
                 className={styles.favoriteItem}
-                onClick={() => setWeatherData(city)}
+                onClick={() => setWeatherData({ city: city.name, id: city.id })}
               >
-                {city.name}
-              </span>
+                {city.name}, {city.country}
+              </button>
             ))}
           </div>
           <button className={styles.clearButton} onClick={removeAllFavorites}>

--- a/client/src/components/WeatherCard.jsx
+++ b/client/src/components/WeatherCard.jsx
@@ -56,7 +56,11 @@ const WeatherCard = () => {
             const favoriteToRemove = favorites.find((fav) => fav.id === cityId);
             removeFromFavorites(favoriteToRemove);
         } else {
-            addToFavorites({ name: weather.name, id: cityId });
+            addToFavorites({
+                name: weather.name,
+                id: cityId,
+                country: weather.sys.country
+            });
         }
     };
 

--- a/client/src/context/FavoritesContext.jsx
+++ b/client/src/context/FavoritesContext.jsx
@@ -30,10 +30,13 @@ export const FavoritesProvider = ({ children }) => {
       })
       .then(data => {
         if (Array.isArray(data)) {
-          setFavorites(data.map(item => ({
-            name: item.city_name,
-            id: item.city_id
-          })));
+          setFavorites(
+            data.map(item => ({
+              name: item.city_name,
+              id: item.city_id,
+              country: item.country
+            }))
+          );
         }
       })
       .catch(err => console.error('Error fetching favorites:', err));
@@ -44,8 +47,11 @@ export const FavoritesProvider = ({ children }) => {
   }, [favorites]);
 
   const addToFavorites = (city) => {
-    if (!favorites.some((item) => item.name === city.name)) {
-      setFavorites((prev) => [{ name: city.name, id: city.id }, ...prev]);
+    if (!favorites.some((item) => item.id === city.id)) {
+      setFavorites((prev) => [
+        { name: city.name, id: city.id, country: city.country },
+        ...prev
+      ]);
       persistFavorite(city);
     }
   };
@@ -58,7 +64,8 @@ export const FavoritesProvider = ({ children }) => {
         body: JSON.stringify({
           user_uuid: userUUID,
           city_name: entry.name,
-          city_id: entry.id
+          city_id: entry.id,
+          country: entry.country
         })
       });
     } catch (error) {

--- a/client/tests/Favorites.test.js
+++ b/client/tests/Favorites.test.js
@@ -52,7 +52,7 @@ describe('FavoritesContext', () => {
       );
     });
 
-    const newCity = { name: 'London', id: 2643743 };
+    const newCity = { name: 'London', id: 2643743, country: 'GB' };
 
     await act(async () => {
       favoritesValue.addToFavorites(newCity);
@@ -78,7 +78,7 @@ describe('FavoritesContext', () => {
       );
     });
 
-    const city = { name: 'London', id: 2643743 };
+    const city = { name: 'London', id: 2643743, country: 'GB' };
 
     await act(async () => {
       favoritesValue.addToFavorites(city);

--- a/server/src/controllers/weatherController.js
+++ b/server/src/controllers/weatherController.js
@@ -149,9 +149,9 @@ const deleteUserHistory = async (req, res) => {
 
 // POST /api/weather/favorites
 const addFavoriteCity = async (req, res) => {
-  const { user_uuid, city_name, city_id } = req.body;
+  const { user_uuid, city_name, city_id, country } = req.body;
 
-  if (!user_uuid || !city_name || !city_id) {
+  if (!user_uuid || !city_name || !city_id || !country) {
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
@@ -159,7 +159,8 @@ const addFavoriteCity = async (req, res) => {
     const newFavorite = new FavoriteCity({
       user_uuid,
       city_name,
-      city_id
+      city_id,
+      country
     });
     await newFavorite.save();
 

--- a/server/src/models/FavoriteCity.js
+++ b/server/src/models/FavoriteCity.js
@@ -9,6 +9,10 @@ const favoriteCitySchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  country: {
+    type: String,
+    required: true
+  },
   city_id: {
     type: Number,
     required: true

--- a/server/tests/favorites.test.js
+++ b/server/tests/favorites.test.js
@@ -22,7 +22,8 @@ describe('Favorites API Endpoints', () => {
       .send({
         user_uuid: 'test-user',
         city_name: 'London',
-        city_id: 12345
+        city_id: 12345,
+        country: 'GB'
       });
 
     expect(response.status).toBe(201);
@@ -33,7 +34,8 @@ describe('Favorites API Endpoints', () => {
     await FavoriteCity.create({
       user_uuid: 'test-user',
       city_name: 'London',
-      city_id: 12345
+      city_id: 12345,
+      country: 'GB'
     });
 
     const response = await request(app)
@@ -48,7 +50,8 @@ describe('Favorites API Endpoints', () => {
     const favorite = await FavoriteCity.create({
       user_uuid: 'test-user',
       city_name: 'London',
-      city_id: 12345
+      city_id: 12345,
+      country: 'GB'
     });
 
     const response = await request(app)

--- a/server/tests/models.test.js
+++ b/server/tests/models.test.js
@@ -24,7 +24,8 @@ describe('FavoriteCity model', () => {
     const favorite = await FavoriteCity.create({
       user_uuid: 'model-test-user',
       city_name: 'Paris',
-      city_id: 98765
+      city_id: 98765,
+      country: 'FR'
     });
 
     expect(favorite.city_name).toBe('Paris');

--- a/server/tests/weather.test.js
+++ b/server/tests/weather.test.js
@@ -131,7 +131,8 @@ describe('Weather API Endpoints', () => {
       const favorite = await FavoriteCity.create({
         user_uuid: 'test-user',
         city_name: 'London',
-        city_id: 12345
+        city_id: 12345,
+        country: 'GB'
       });
 
       const response = await request(app)


### PR DESCRIPTION
## Summary
- extend `FavoriteCity` model with `country` field
- persist country in favorites controller
- show `city, country` in the favorites list
- save country in favorites context and on star click
- update tests for new favorites shape

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f5526afc832b9a57db393992d778